### PR TITLE
Move Regex tests off docstrings

### DIFF
--- a/formlessness/constraints.py
+++ b/formlessness/constraints.py
@@ -392,21 +392,9 @@ class Regex(Constraint[str]):
         self.message = message
 
     def satisfied_by(self, value: str) -> bool:
-        r"""
-        >>> Regex("\w+").satisfied_by("snake_case")
-        True
-        >>> Regex("\w").satisfied_by("snake_case")
-        False
-        >>> Regex("\w+").satisfied_by("abc!")
-        False
-        """
         return self.pattern.fullmatch(value) is not None
 
     def __str__(self) -> str:
-        r"""
-        >>> print(Regex("\w+"))
-        Must match regex \w+
-        """
         return self.message or f"Must match regex {self.pattern.pattern}"
 
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1,6 +1,15 @@
 from formlessness.constraints import GE
 from formlessness.constraints import Comparison
+from formlessness.constraints import Regex
 from formlessness.constraints import to_json
+
+
+def test_regex():
+    constraint = Regex(r"\w+")
+    assert constraint.satisfied_by("snake_case")
+    assert not constraint.satisfied_by("abc!")
+    assert str(constraint) == r"Must match regex \w+"
+    assert not Regex(r"\w").satisfied_by("snake_case")
 
 
 def test_json_ge():


### PR DESCRIPTION
These were causing warnings. Moving them out to get things passing, then may move back.
